### PR TITLE
[WIP] Configurable layer import: Please discuss

### DIFF
--- a/src/componentHelpers.js
+++ b/src/componentHelpers.js
@@ -2,17 +2,19 @@ import React from 'react';
 import TextField from 'material-ui/TextField';
 import SelectField from 'material-ui/SelectField';
 
-export const textFieldForKey = (keyName, value, changeCallback) => {
+export const textFieldForKey = (keyName, value, changeCallback, label='') => {
   return (<TextField
+          floatingLabelText={label}
           key={keyName}
           name={keyName}
           value={value}
           onChange={(event, newValue) => { changeCallback(keyName, newValue)}}/>
         )
 }
-export const selectFieldForKey = (keyName, items, value, changeCallback) => {
+export const selectFieldForKey = (keyName, items, value, changeCallback, label='') => {
   return (<SelectField
     key={keyName}
+    floatingLabelText={label}
     onChange={(event, index, newValue) => { changeCallback(keyName, newValue)}}
     value={value}
     >

--- a/src/componentHelpers.js
+++ b/src/componentHelpers.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import TextField from 'material-ui/TextField';
+import SelectField from 'material-ui/SelectField';
 
 export const textFieldForKey = (keyName, value, changeCallback) => {
   return (<TextField
@@ -7,4 +8,12 @@ export const textFieldForKey = (keyName, value, changeCallback) => {
     value={value}
     onChange={(event, newValue) => { changeCallback(keyName, newValue)}}/>
   )
+}
+export const selectFieldForKey = (keyName, items, value, changeCallback) => {
+  return (<SelectField
+    onChange={(event, index, newValue) => { changeCallback(keyName, newValue)}}
+    value={value}
+    >
+      {items}
+    </SelectField>);
 }

--- a/src/componentHelpers.js
+++ b/src/componentHelpers.js
@@ -4,13 +4,15 @@ import SelectField from 'material-ui/SelectField';
 
 export const textFieldForKey = (keyName, value, changeCallback) => {
   return (<TextField
-    name={keyName}
-    value={value}
-    onChange={(event, newValue) => { changeCallback(keyName, newValue)}}/>
-  )
+          key={keyName}
+          name={keyName}
+          value={value}
+          onChange={(event, newValue) => { changeCallback(keyName, newValue)}}/>
+        )
 }
 export const selectFieldForKey = (keyName, items, value, changeCallback) => {
   return (<SelectField
+    key={keyName}
     onChange={(event, index, newValue) => { changeCallback(keyName, newValue)}}
     value={value}
     >

--- a/src/componentHelpers.js
+++ b/src/componentHelpers.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import TextField from 'material-ui/TextField';
+
+export const textFieldForKey = (keyName, value, changeCallback) => {
+  return (<TextField
+    name={keyName}
+    value={value}
+    onChange={(event, newValue) => { changeCallback(keyName, newValue)}}/>
+  )
+}

--- a/src/components/layerImport.jsx
+++ b/src/components/layerImport.jsx
@@ -35,7 +35,7 @@ export default class LayerImport extends React.PureComponent {
       layerName: props.layer.name
     }
     Object.keys(props.config.steps).map((d, i) => {
-      props.config.steps[d].steps.forEach( (d) => {
+      props.config.steps[d].fields.forEach( (d) => {
         this.state[d.api_name] = props.layer[d.api_name];
       });
     });
@@ -111,15 +111,15 @@ export default class LayerImport extends React.PureComponent {
       actions.push(createAction);
     }else {
       let {layer} = this.props;
-      let {title, steps}= this.props.config.steps[this.state.step];
+      let {title, fields}= this.props.config.steps[this.state.step];
       let headline = (<h1>{title}</h1>)
-      let fields = steps.map( (d, i) => {
+      let fieldItems = fields.map( (d, i) => {
         let {subtitle, api_name, type} = d;
         let field;
         if(type === "text") {
-          field = textFieldForKey(api_name, this.state[api_name], this._handleInputChange.bind(this))
+          field = textFieldForKey(api_name, this.state[api_name], this._handleInputChange.bind(this), subtitle)
         }else if(type === "fields") {
-          field = selectFieldForKey(api_name, this.menuItems(this.apiItems), this.state[api_name], this._handleInputChange.bind(this));
+          field = selectFieldForKey(api_name, this.menuItems(this.apiItems), this.state[api_name], this._handleInputChange.bind(this), subtitle);
         }
         const elem = (<div key={i}>{field}<br/></div>);
         return elem;
@@ -127,7 +127,7 @@ export default class LayerImport extends React.PureComponent {
       const className = `step-${this.state.step}`
       stepElem = (<div className={className}>
                   {headline}
-                  {fields}
+                  {fieldItems}
                   </div>
                  );
     }

--- a/src/components/layerImport.jsx
+++ b/src/components/layerImport.jsx
@@ -6,7 +6,11 @@ import Toggle from 'material-ui/Toggle';
 import Wizard from './step';
 import RaisedButton from 'material-ui/RaisedButton';
 import FlatButton from 'material-ui/FlatButton';
-import {textFieldForKey} from '../componentHelpers.js'
+import {textFieldForKey, selectFieldForKey} from '../componentHelpers.js'
+import MenuItem from 'material-ui/MenuItem';
+
+import injectTapEventPlugin from 'react-tap-event-plugin';
+injectTapEventPlugin();
 
 import {isLayerImported, singleImportStarted} from '../state/uploads/selectors';
 
@@ -29,6 +33,7 @@ export default class LayerImport extends React.PureComponent {
     }
     let configArray = this.generateConfigArray(config)
     this.stepContent = this.generateStepContent(configArray);
+    this.apiItems = Object.keys(props.layer);
     this.state= {
       show: false,
       step: 1,
@@ -54,11 +59,17 @@ export default class LayerImport extends React.PureComponent {
       configArray.push({title: 'Layer Name', api_name: 'layerName', type: 'text'});
     }
     if(config.edit_time) {
-      configArray.push({title: 'Time', api_name: 'time', type: 'date'});
+      configArray.push({title: 'Start Date', api_name: 'start_date', type: 'fields'});
+      configArray.push({title: 'End Date', api_name: 'end_date', type: 'fields'});
     }
     if(config.edit_permission) {
     }
     return configArray.concat(config.other);
+  }
+  generateApiItems(layer) {
+    return configArray.map( (d, index) => {
+      return {title: d.title, value: d.api_name };
+    });
   }
   generateStepContent(configArray) {
     let stepContent = [];
@@ -97,6 +108,15 @@ export default class LayerImport extends React.PureComponent {
     this.props.configureLayerWithName(this.state.layerName, this.props.id);
     this.setState({importing: true});
   }
+  menuItems(items) {
+    return items.map((item, index) => (
+      <MenuItem
+        key={index}
+        value={item}
+        primaryText={item}
+      />
+    ));
+  }
   render() {
     let stepElem;
     let toggleStyle = { margin: 10 }
@@ -121,6 +141,8 @@ export default class LayerImport extends React.PureComponent {
       let field;
       if(type === "text") {
         field = textFieldForKey(api_name, this.state[api_name], this._handleInputChange.bind(this))
+      }else if(type === "fields") {
+        field = selectFieldForKey(api_name, this.menuItems(this.apiItems), this.state[api_name], this._handleInputChange.bind(this));
       }
       const className = `step-${this.state.step}`
       stepElem = (<div className={className}>

--- a/src/components/layerImportLink.js
+++ b/src/components/layerImportLink.js
@@ -1,19 +1,27 @@
 import {connect} from 'react-redux';
 import LayerImport from './layerImport'
 import {configureUploads} from '../state/uploads/actions'
-import {createLayerConfigWithName} from '../services/geonode'
+import {createLayerConfigWithName} from '../services/config'
 
 function mapStateToProps(state) {
   const {server, uploads} = state;
   return {
     server,
-    uploads
+    uploads,
+    config: {
+      edit_name: true,
+      edit_time: false,
+      other: []
+    }
   };
 }
 const mapDispatchToProps = (dispatch) => {
   return {
     configureLayerWithName: (name, index) => {
       dispatch(configureUploads(createLayerConfigWithName(name), index));
+    },
+    configureLayerWithConfig: (config, index) => {
+      dispatch(configureUploads(config, index));
     }
   }
 }

--- a/src/services/config.js
+++ b/src/services/config.js
@@ -1,9 +1,14 @@
 
 export const getDefaultConfig = () => {
   return {
-    edit_name: true,
-    edit_time: false,
-    other: []
+    steps: {
+      1: {
+        title: 'Layer Name',
+        steps: [
+          { title: '', api_name: 'layer_name', type: 'text'}
+        ]
+      }
+    }
   }
 }
 export const generateConfigArray = (config) => {
@@ -30,10 +35,12 @@ export const generateTitleArray = (config) => {
 export const createLayerConfigWithName = (name) => {
   return { index: 0, permissions: {'users':{'AnonymousUser':['change_layer_data', 'download_resourcebase', 'view_resourcebase']}}, configureTime: false, convert_to_date: [], editable: true, start_date: null, end_date: null, layer_name: name}
 }
-export const createLayerConfigFromConfigArray = (configArray, values) => {
+export const createLayerConfigFromConfigArray = (config, values) => {
   let defaultConfig = { index: 0, permissions: {'users':{'AnonymousUser':['change_layer_data', 'download_resourcebase', 'view_resourcebase']}}, configureTime: false, convert_to_date: [], editable: true, start_date: null, end_date: null, layer_name: null};
-  configArray.forEach( (d) => {
-    defaultConfig[d.api_name] = values[d.api_name];
-  })
+  Object.keys(config.steps).map((d, i) => {
+    config.steps[d].steps.forEach( (d) => {
+      defaultConfig[d.api_name] = values[d.api_name];
+    });
+  });
   return defaultConfig;
 }

--- a/src/services/config.js
+++ b/src/services/config.js
@@ -1,0 +1,39 @@
+
+export const getDefaultConfig = () => {
+  return {
+    edit_name: true,
+    edit_time: false,
+    other: []
+  }
+}
+export const generateConfigArray = (config) => {
+  let configArray = [];
+  if(config.edit_name) {
+    configArray.push({title: 'Layer Name', api_name: 'layerName', type: 'text'});
+  }
+  if(config.edit_time) {
+    configArray.push({title: 'Start Date', api_name: 'start_date', type: 'fields'});
+    configArray.push({title: 'End Date', api_name: 'end_date', type: 'fields'});
+  }
+  if(config.edit_permission) {
+  }
+  if(config.other.length > 0) {
+    return configArray.concat(config.other);
+  }
+  return configArray;
+}
+export const generateTitleArray = (config) => {
+  return config.map( (d, index) => {
+    return d.title;
+  });
+}
+export const createLayerConfigWithName = (name) => {
+  return { index: 0, permissions: {'users':{'AnonymousUser':['change_layer_data', 'download_resourcebase', 'view_resourcebase']}}, configureTime: false, convert_to_date: [], editable: true, start_date: null, end_date: null, layer_name: name}
+}
+export const createLayerConfigFromConfigArray = (configArray, values) => {
+  let defaultConfig = { index: 0, permissions: {'users':{'AnonymousUser':['change_layer_data', 'download_resourcebase', 'view_resourcebase']}}, configureTime: false, convert_to_date: [], editable: true, start_date: null, end_date: null, layer_name: null};
+  configArray.forEach( (d) => {
+    defaultConfig[d.api_name] = values[d.api_name];
+  })
+  return defaultConfig;
+}

--- a/src/services/config.js
+++ b/src/services/config.js
@@ -1,36 +1,19 @@
-
+let getClass = {}.toString,
+    hasProperty = {}.hasOwnProperty;
+function isFunction(object) {
+ return object && getClass.call(object) == '[object Function]';
+}
 export const getDefaultConfig = () => {
   return {
     steps: {
       1: {
         title: 'Layer Name',
-        steps: [
+        fields: [
           { title: '', api_name: 'layer_name', type: 'text'}
         ]
       }
     }
   }
-}
-export const generateConfigArray = (config) => {
-  let configArray = [];
-  if(config.edit_name) {
-    configArray.push({title: 'Layer Name', api_name: 'layerName', type: 'text'});
-  }
-  if(config.edit_time) {
-    configArray.push({title: 'Start Date', api_name: 'start_date', type: 'fields'});
-    configArray.push({title: 'End Date', api_name: 'end_date', type: 'fields'});
-  }
-  if(config.edit_permission) {
-  }
-  if(config.other.length > 0) {
-    return configArray.concat(config.other);
-  }
-  return configArray;
-}
-export const generateTitleArray = (config) => {
-  return config.map( (d, index) => {
-    return d.title;
-  });
 }
 export const createLayerConfigWithName = (name) => {
   return { index: 0, permissions: {'users':{'AnonymousUser':['change_layer_data', 'download_resourcebase', 'view_resourcebase']}}, configureTime: false, convert_to_date: [], editable: true, start_date: null, end_date: null, layer_name: name}
@@ -38,8 +21,17 @@ export const createLayerConfigWithName = (name) => {
 export const createLayerConfigFromConfigArray = (config, values) => {
   let defaultConfig = { index: 0, permissions: {'users':{'AnonymousUser':['change_layer_data', 'download_resourcebase', 'view_resourcebase']}}, configureTime: false, convert_to_date: [], editable: true, start_date: null, end_date: null, layer_name: null};
   Object.keys(config.steps).map((d, i) => {
-    config.steps[d].steps.forEach( (d) => {
-      defaultConfig[d.api_name] = values[d.api_name];
+    config.steps[d].fields.forEach( (d) => {
+      if(!(typeof values[d.api_name] === 'undefined' || values[d.api_name] === null )) {
+        defaultConfig[d.api_name] = values[d.api_name];
+      }
+      if(d.type === 'hidden' && (!d.parent || (d.parent && values[d.parent]))) {
+        if(isFunction(d.value)) {
+          defaultConfig[d.api_name] = d.value(values);
+        } else {
+          defaultConfig[d.api_name] = d.value;
+        }
+      }
     });
   });
   return defaultConfig;

--- a/src/services/geonode.js
+++ b/src/services/geonode.js
@@ -27,10 +27,6 @@ const createSimpleRequestObject = function(method) {
     };
 };
 
-export const createLayerConfigWithName = (name) => {
-  return { index: 0, permissions: {'users':{'AnonymousUser':['change_layer_data', 'download_resourcebase', 'view_resourcebase']}}, configureTime: false, convert_to_date: [], editable: true, start_date: null, end_date: null, layer_name: name}
-}
-
 export const uploadFiles = (server, files) => {
 	var data = new FormData();
   files.forEach((file)=> {

--- a/src/services/geonode.js
+++ b/src/services/geonode.js
@@ -67,3 +67,18 @@ export const uploadedData = (server, id) => {
     .then((response) => response.json())
     .catch((ex) => Promise.reject(ex));
 };
+
+export const getUsers = (server, query) => {
+	var request = createRequestObject('POST', JSON.stringify(query));
+  var requestPath = `${server}/account/ajax_lookup`;
+  return fetch(requestPath,request)
+    .then((response) => response.json())
+    .catch((ex) => Promise.reject(ex));
+};
+export const genericPost = (server, endpoint, query) => {
+	var request = createRequestObject('POST', JSON.stringify(query));
+  var requestPath = `${server}/${endpoint}`;
+  return fetch(requestPath,request)
+    .then((response) => response.json())
+    .catch((ex) => Promise.reject(ex));
+};

--- a/tests/components/layerImport.test.js
+++ b/tests/components/layerImport.test.js
@@ -18,7 +18,7 @@ describe('LayerImport', () => {
   beforeEach(() => {
     layerName = {
           title: 'Layer Name',
-          steps: [
+          fields: [
             { title: '', api_name: 'layer_name', type: 'text'}
           ]
         };
@@ -49,9 +49,10 @@ describe('LayerImport', () => {
     expect(wrapper.state('layer_name')).to.equal('Test');
 	});
   it('shows select field correctly', () => {
-    let date = { title: 'Dates', steps: [
+    let date = { title: 'Dates', fields: [
       {title: 'Start Date', api_name: 'start_date', type: 'fields'},
-      {title: 'End Date', api_name: 'end_date', type: 'fields'}
+      {title: 'End Date', api_name: 'end_date', type: 'fields'},
+      {title: '', api_name: 'configureTime', type: 'hidden', value: true}
     ]};
     const config = Object.assign({}, defaultConfig, {steps: {1: layerName, 2: date }});
     const layer = { layerName: 'Test', import_status: ''};

--- a/tests/components/layerImport.test.js
+++ b/tests/components/layerImport.test.js
@@ -14,17 +14,19 @@ import td from 'testdouble';
 
 
 describe('LayerImport', () => {
-  let defaultConfig;
+  let defaultConfig, layerName;
   beforeEach(() => {
+    layerName = {
+          title: 'Layer Name',
+          steps: [
+            { title: '', api_name: 'layer_name', type: 'text'}
+          ]
+        };
     defaultConfig = {
-      edit_name: true,
-      edit_time: false,
-      other: [{
-        title: 'GeoGig',
-        api_name: 'geogig',
-        type: 'text'
-      }]
-    };
+      steps: {
+        1: layerName
+      }
+    }
   });
 	it('exists', () => {
     const layer = { name: 'Test', import_status: ''};
@@ -34,7 +36,7 @@ describe('LayerImport', () => {
 	it('shows the correct content', () => {
     const layer = { name: 'Test', import_status: ''};
     const wrapper = shallow(<LayerImport config={defaultConfig} layer={layer}/>);
-    expect(wrapper.state('steps')).to.equal(3);
+    expect(wrapper.state('steps')).to.equal(2);
 	});
 	it('shows the layer name field', () => {
     const layer = { name: 'Test', import_status: ''};
@@ -42,37 +44,58 @@ describe('LayerImport', () => {
     expect(wrapper.find(Dialog).childAt(0).childAt(0).hasClass('step-1')).to.equal(true);
 	});
 	it('has the correct state', () => {
-    const layer = { layerName: 'Test', import_status: ''};
+    const layer = { layer_name: 'Test', import_status: ''};
     const wrapper = shallow(<LayerImport config={defaultConfig} layer={layer}/>);
-    expect(wrapper.state('layerName')).to.equal('Test');
+    expect(wrapper.state('layer_name')).to.equal('Test');
 	});
   it('shows select field correctly', () => {
-    const config = Object.assign({}, defaultConfig, {edit_time: true});
+    let date = { title: 'Dates', steps: [
+      {title: 'Start Date', api_name: 'start_date', type: 'fields'},
+      {title: 'End Date', api_name: 'end_date', type: 'fields'}
+    ]};
+    const config = Object.assign({}, defaultConfig, {steps: {1: layerName, 2: date }});
     const layer = { layerName: 'Test', import_status: ''};
     const wrapper = shallow(<LayerImport config={config} layer={layer}/>);
-    wrapper.setState({step: 3});
-    expect(wrapper.find(SelectField)).to.have.length(1);
+    wrapper.setState({step: 2});
+    expect(wrapper.find(SelectField)).to.have.length(2);
   });
-  it('import is called', () => {
-    let config = {
-      edit_name: true,
-      edit_time: false,
-      other: []
-    }
-    const layer = { layerName: 'Test', import_status: ''};
-    const configureLayer = td.function();
-    const muiTheme = getMuiTheme();
-    const uploads = { importLayers: { started: false, single: {}}};
-    const root = document.createElement("div");
-    document.body.appendChild(root);
-    const wrapper = mount(<LayerImport uploads={uploads} configureLayerWithConfig={configureLayer} config={config} layer={layer}/>,{
-        context: {muiTheme},
-        childContextTypes: {muiTheme: React.PropTypes.object},
-        attachTo: root
+  describe('import', () => {
+    let layer, configureLayer, muiTheme, uploads, root;
+    beforeEach( () => {
+      layer = { layer_name: 'Test', import_status: ''};
+      configureLayer = td.function();
+      muiTheme = getMuiTheme();
+      uploads = { importLayers: { started: false, single: {}}};
+      root = document.createElement("div");
+      document.body.appendChild(root);
     });
-    wrapper.setState({step: 2, show: true});
-    const confirm = document.body.querySelector(".import-btn button");
-    ReactTestUtils.Simulate.click(confirm);
-    expect(configureLayer).to.have.been.called;
-  });
+    afterEach( () => {
+      document.body.removeChild(root);
+    });
+    it('import is called', () => {
+      const wrapper = mount(<LayerImport uploads={uploads} configureLayerWithConfig={configureLayer} config={defaultConfig} layer={layer}/>,{
+          context: {muiTheme},
+          childContextTypes: {muiTheme: React.PropTypes.object},
+          attachTo: root
+      });
+      wrapper.setState({step: 2, show: true});
+      const confirm = document.body.querySelector(".import-btn button");
+      ReactTestUtils.Simulate.click(confirm);
+      expect(configureLayer).to.have.been.called;
+      wrapper.detach();
+    });
+    it('import is called with the corect config', () => {
+      const result = { index: 0, permissions: {'users':{'AnonymousUser':['change_layer_data', 'download_resourcebase', 'view_resourcebase']}}, configureTime: false, convert_to_date: [], editable: true, start_date: null, end_date: null, layer_name: 'Test'};
+      const wrapper = mount(<LayerImport id={1} uploads={uploads} configureLayerWithConfig={configureLayer} config={defaultConfig} layer={layer}/>,{
+          context: {muiTheme},
+          childContextTypes: {muiTheme: React.PropTypes.object},
+          attachTo: root
+      });
+      wrapper.setState({step: 2, show: true});
+      const confirm = document.body.querySelector(".import-btn button");
+      ReactTestUtils.Simulate.click(confirm);
+      expect(configureLayer).to.have.been.calledWith(result, 1);
+      wrapper.detach();
+    });
+  })
 });

--- a/tests/components/layerImport.test.js
+++ b/tests/components/layerImport.test.js
@@ -1,33 +1,78 @@
 import ReactTestUtils from 'react-addons-test-utils';
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 
 import LayerImport from '../../src/components/layerImport';
 import {Wizard} from '../../src/components/step';
 
 import RaisedButton from 'material-ui/RaisedButton';
 import Dialog from 'material-ui/Dialog';
+import SelectField from 'material-ui/SelectField';
+import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
+import getMuiTheme from 'material-ui/styles/getMuiTheme';
+
+import td from 'testdouble';
 
 
 describe('LayerImport', () => {
+  let defaultConfig;
+  beforeEach(() => {
+    defaultConfig = {
+      edit_name: true,
+      edit_time: false,
+      other: [{
+        title: 'GeoGig',
+        api_name: 'geogig',
+        type: 'text'
+      }]
+    };
+  });
 	it('exists', () => {
     const layer = { name: 'Test', import_status: ''};
-    const wrapper = shallow(<LayerImport layer={layer}/>);
+    const wrapper = shallow(<LayerImport config={defaultConfig} layer={layer}/>);
     expect(wrapper.find(Dialog)).to.have.length(1);
-    console.log(wrapper.find(Dialog).children)
 	});
 	it('shows the correct content', () => {
     const layer = { name: 'Test', import_status: ''};
-    const wrapper = shallow(<LayerImport layer={layer}/>);
+    const wrapper = shallow(<LayerImport config={defaultConfig} layer={layer}/>);
     expect(wrapper.state('steps')).to.equal(3);
 	});
 	it('shows the layer name field', () => {
     const layer = { name: 'Test', import_status: ''};
-    const wrapper = shallow(<LayerImport layer={layer}/>);
+    const wrapper = shallow(<LayerImport config={defaultConfig} layer={layer}/>);
     expect(wrapper.find(Dialog).childAt(0).childAt(0).hasClass('step-1')).to.equal(true);
 	});
 	it('has the correct state', () => {
     const layer = { layerName: 'Test', import_status: ''};
-    const wrapper = shallow(<LayerImport layer={layer}/>);
+    const wrapper = shallow(<LayerImport config={defaultConfig} layer={layer}/>);
     expect(wrapper.state('layerName')).to.equal('Test');
 	});
+  it('shows select field correctly', () => {
+    const config = Object.assign({}, defaultConfig, {edit_time: true});
+    const layer = { layerName: 'Test', import_status: ''};
+    const wrapper = shallow(<LayerImport config={config} layer={layer}/>);
+    wrapper.setState({step: 3});
+    expect(wrapper.find(SelectField)).to.have.length(1);
+  });
+  it('import is called', () => {
+    let config = {
+      edit_name: true,
+      edit_time: false,
+      other: []
+    }
+    const layer = { layerName: 'Test', import_status: ''};
+    const configureLayer = td.function();
+    const muiTheme = getMuiTheme();
+    const uploads = { importLayers: { started: false, single: {}}};
+    const root = document.createElement("div");
+    document.body.appendChild(root);
+    const wrapper = mount(<LayerImport uploads={uploads} configureLayerWithConfig={configureLayer} config={config} layer={layer}/>,{
+        context: {muiTheme},
+        childContextTypes: {muiTheme: React.PropTypes.object},
+        attachTo: root
+    });
+    wrapper.setState({step: 2, show: true});
+    const confirm = document.body.querySelector(".import-btn button");
+    ReactTestUtils.Simulate.click(confirm);
+    expect(configureLayer).to.have.been.called;
+  });
 });

--- a/tests/components/layerImport.test.js
+++ b/tests/components/layerImport.test.js
@@ -1,0 +1,33 @@
+import ReactTestUtils from 'react-addons-test-utils';
+import { shallow } from 'enzyme';
+
+import LayerImport from '../../src/components/layerImport';
+import {Wizard} from '../../src/components/step';
+
+import RaisedButton from 'material-ui/RaisedButton';
+import Dialog from 'material-ui/Dialog';
+
+
+describe('LayerImport', () => {
+	it('exists', () => {
+    const layer = { name: 'Test', import_status: ''};
+    const wrapper = shallow(<LayerImport layer={layer}/>);
+    expect(wrapper.find(Dialog)).to.have.length(1);
+    console.log(wrapper.find(Dialog).children)
+	});
+	it('shows the correct content', () => {
+    const layer = { name: 'Test', import_status: ''};
+    const wrapper = shallow(<LayerImport layer={layer}/>);
+    expect(wrapper.state('steps')).to.equal(3);
+	});
+	it('shows the layer name field', () => {
+    const layer = { name: 'Test', import_status: ''};
+    const wrapper = shallow(<LayerImport layer={layer}/>);
+    expect(wrapper.find(Dialog).childAt(0).childAt(0).hasClass('step-1')).to.equal(true);
+	});
+	it('has the correct state', () => {
+    const layer = { layerName: 'Test', import_status: ''};
+    const wrapper = shallow(<LayerImport layer={layer}/>);
+    expect(wrapper.state('layerName')).to.equal('Test');
+	});
+});

--- a/tests/service/config.test.js
+++ b/tests/service/config.test.js
@@ -1,0 +1,60 @@
+import {getDefaultConfig, generateConfigArray, generateTitleArray, createLayerConfigFromConfigArray} from '../../src/services/config';
+
+describe('config', () => {
+  let defaultConfig;
+  beforeEach( () => {
+    defaultConfig = {
+      edit_name: true,
+      edit_time: false,
+      other: []
+    }
+  });
+  describe('#defaultConfig', () => {
+    it('returns result', () => {
+      return assert.deepEqual(getDefaultConfig(), defaultConfig);
+    });
+  });
+  describe('#generateConfigArray', () => {
+    it('returns correct number of objects', () => {
+      return assert.equal(generateConfigArray(defaultConfig).length, 1);
+    });
+    it('layerName is the first item', () => {
+      let layerName = {title: 'Layer Name', api_name: 'layerName', type: 'text'}
+      return assert.deepEqual(generateConfigArray(defaultConfig)[0], layerName);
+    });
+    describe('include time config', () => {
+      let config;
+      beforeEach( () => {
+        config = Object.assign(defaultConfig, {edit_time: true})
+      })
+      it('returns correct number of objects', () => {
+        return assert.equal(generateConfigArray(config).length, 3);
+      });
+      it('Start Date is the first item', () => {
+        let startDate = {title: 'Start Date', api_name: 'start_date', type: 'fields'};
+        return assert.deepEqual(generateConfigArray(config)[1], startDate);
+      });
+    });
+  });
+  describe('#generateTitleArray', () => {
+    let configArray;
+    beforeEach( () => {
+      configArray = [{title: 'Padres'}];
+    })
+    it('returns correct number of objects', () => {
+      return assert.equal(generateTitleArray(configArray).length, 1);
+    });
+    it('first element is the title', () => {
+      return assert.equal(generateTitleArray(configArray)[0], 'Padres');
+    });
+  });
+  describe('#createLayerConfigFromConfigArray', () => {
+    it('returns the bare minimum with just a new name', () => {
+      let configArray = [{title: 'Layer Name', api_name: 'layer_name'}];
+      let values = { layer_name: 'Padres'};
+      let name = 'Padres';
+      let layerConfig = { index: 0, permissions: {'users':{'AnonymousUser':['change_layer_data', 'download_resourcebase', 'view_resourcebase']}}, configureTime: false, convert_to_date: [], editable: true, start_date: null, end_date: null, layer_name: name}
+      return assert.deepEqual(createLayerConfigFromConfigArray(configArray, values), layerConfig);
+    });
+  });
+})

--- a/tests/service/config.test.js
+++ b/tests/service/config.test.js
@@ -7,7 +7,7 @@ describe('config', () => {
       steps: {
         1: {
           title: 'Layer Name',
-          steps: [
+          fields: [
             { title: '', api_name: 'layer_name', type: 'text'}
           ]
         }
@@ -24,6 +24,103 @@ describe('config', () => {
       let values = { layer_name: 'Padres'};
       let name = 'Padres';
       let layerConfig = { index: 0, permissions: {'users':{'AnonymousUser':['change_layer_data', 'download_resourcebase', 'view_resourcebase']}}, configureTime: false, convert_to_date: [], editable: true, start_date: null, end_date: null, layer_name: name}
+      return assert.deepEqual(createLayerConfigFromConfigArray(defaultConfig, values), layerConfig);
+    });
+  });
+  describe('time enabled', () => {
+    beforeEach( () => {
+      defaultConfig = {
+        steps: {
+          1: {
+            title: 'Layer Name',
+            fields: [
+              { title: '', api_name: 'layer_name', type: 'text'}
+            ]
+          },
+          2: { title: 'Dates', fields: [
+            {title: 'Start Date', api_name: 'start_date', type: 'fields'},
+            {title: 'End Date', api_name: 'end_date', type: 'fields'},
+            {title: '', api_name: 'configureTime', type: 'hidden', value: true, parent: 'start_date'},
+            {title: '', api_name: 'convert_to_date', type: 'hidden', value: (d) => { return [d.start_date]}, parent: 'start_date'}
+          ]}
+        }
+      }
+    });
+    it('returns the config with time enabled', () => {
+      let values = { layer_name: 'Padres', start_date: 'date'};
+      let name = 'Padres';
+      let layerConfig = { index: 0, permissions: {'users':{'AnonymousUser':['change_layer_data', 'download_resourcebase', 'view_resourcebase']}}, configureTime: true, convert_to_date: ['date'], editable: true, start_date: 'date', end_date: null, layer_name: name}
+      return assert.deepEqual(createLayerConfigFromConfigArray(defaultConfig, values), layerConfig);
+    });
+  });
+  describe('geogig enabled', () => {
+    beforeEach( () => {
+      defaultConfig = {
+        steps: {
+          1: {
+            title: 'Layer Name',
+            fields: [
+              { title: '', api_name: 'layer_name', type: 'text'}
+            ]
+          },
+          2: {
+            title: 'Version Control',
+            fields: [
+              {title: '', api_name: 'editable', type: 'switch', values: [true, false]},
+              {title: '', api_name: 'geoserver_store', type: 'hidden', value: {'type': 'geogig'}, parent: 'editable'}
+            ]
+          }
+        }
+      }
+    });
+    it('returns the config with geogig enabled', () => {
+      let values = { layer_name: 'Padres', editable: true};
+      let name = 'Padres';
+      let layerConfig = { index: 0, permissions: {'users':{'AnonymousUser':['change_layer_data', 'download_resourcebase', 'view_resourcebase']}}, configureTime: false, convert_to_date: [], editable: true, geoserver_store: {type: 'geogig'}, start_date: null, end_date: null, layer_name: name}
+      return assert.deepEqual(createLayerConfigFromConfigArray(defaultConfig, values), layerConfig);
+    });
+    it('returns the config no geogig', () => {
+      let values = { layer_name: 'Padres', editable: false};
+      let name = 'Padres';
+      let layerConfig = { index: 0, permissions: {'users':{'AnonymousUser':['change_layer_data', 'download_resourcebase', 'view_resourcebase']}}, configureTime: false, convert_to_date: [], editable: false, start_date: null, end_date: null, layer_name: name}
+      return assert.deepEqual(createLayerConfigFromConfigArray(defaultConfig, values), layerConfig);
+    });
+  });
+  describe('hidden', () => {
+    beforeEach( () => {
+      defaultConfig = {
+        steps: {
+          1: {
+            title: 'Layer Name',
+            fields: [
+              { title: '', api_name: 'layer_name', type: 'text'},
+              { title: '', api_name: 'no_parent', type: 'hidden', value: 'yes'}
+            ]
+          }
+        }
+      }
+    });
+    it('has no parent requirement, set the value no_parent', () => {
+      let values = { layer_name: 'Padres'};
+      let name = 'Padres';
+      let layerConfig = { index: 0, permissions: {'users':{'AnonymousUser':['change_layer_data', 'download_resourcebase', 'view_resourcebase']}}, configureTime: false, convert_to_date: [], editable: true, start_date: null, end_date: null, layer_name: name, no_parent: 'yes'}
+      return assert.deepEqual(createLayerConfigFromConfigArray(defaultConfig, values), layerConfig);
+    });
+    it('does not set the second value if parent is not set', () => {
+      defaultConfig = {
+        steps: {
+          1: {
+            title: 'Layer Name',
+            fields: [
+              { title: '', api_name: 'layer_name', type: 'text'},
+              { title: '', api_name: 'parent', type: 'hidden', value: 'yes', parent: 'layer_name'}
+            ]
+          }
+        }
+      }
+      let values = {};
+      let name = 'Padres';
+      let layerConfig = { index: 0, permissions: {'users':{'AnonymousUser':['change_layer_data', 'download_resourcebase', 'view_resourcebase']}}, configureTime: false, convert_to_date: [], editable: true, start_date: null, end_date: null, layer_name: null}
       return assert.deepEqual(createLayerConfigFromConfigArray(defaultConfig, values), layerConfig);
     });
   });

--- a/tests/service/config.test.js
+++ b/tests/service/config.test.js
@@ -4,9 +4,14 @@ describe('config', () => {
   let defaultConfig;
   beforeEach( () => {
     defaultConfig = {
-      edit_name: true,
-      edit_time: false,
-      other: []
+      steps: {
+        1: {
+          title: 'Layer Name',
+          steps: [
+            { title: '', api_name: 'layer_name', type: 'text'}
+          ]
+        }
+      }
     }
   });
   describe('#defaultConfig', () => {
@@ -14,47 +19,12 @@ describe('config', () => {
       return assert.deepEqual(getDefaultConfig(), defaultConfig);
     });
   });
-  describe('#generateConfigArray', () => {
-    it('returns correct number of objects', () => {
-      return assert.equal(generateConfigArray(defaultConfig).length, 1);
-    });
-    it('layerName is the first item', () => {
-      let layerName = {title: 'Layer Name', api_name: 'layerName', type: 'text'}
-      return assert.deepEqual(generateConfigArray(defaultConfig)[0], layerName);
-    });
-    describe('include time config', () => {
-      let config;
-      beforeEach( () => {
-        config = Object.assign(defaultConfig, {edit_time: true})
-      })
-      it('returns correct number of objects', () => {
-        return assert.equal(generateConfigArray(config).length, 3);
-      });
-      it('Start Date is the first item', () => {
-        let startDate = {title: 'Start Date', api_name: 'start_date', type: 'fields'};
-        return assert.deepEqual(generateConfigArray(config)[1], startDate);
-      });
-    });
-  });
-  describe('#generateTitleArray', () => {
-    let configArray;
-    beforeEach( () => {
-      configArray = [{title: 'Padres'}];
-    })
-    it('returns correct number of objects', () => {
-      return assert.equal(generateTitleArray(configArray).length, 1);
-    });
-    it('first element is the title', () => {
-      return assert.equal(generateTitleArray(configArray)[0], 'Padres');
-    });
-  });
   describe('#createLayerConfigFromConfigArray', () => {
     it('returns the bare minimum with just a new name', () => {
-      let configArray = [{title: 'Layer Name', api_name: 'layer_name'}];
       let values = { layer_name: 'Padres'};
       let name = 'Padres';
       let layerConfig = { index: 0, permissions: {'users':{'AnonymousUser':['change_layer_data', 'download_resourcebase', 'view_resourcebase']}}, configureTime: false, convert_to_date: [], editable: true, start_date: null, end_date: null, layer_name: name}
-      return assert.deepEqual(createLayerConfigFromConfigArray(configArray, values), layerConfig);
+      return assert.deepEqual(createLayerConfigFromConfigArray(defaultConfig, values), layerConfig);
     });
   });
 })

--- a/tests/service/geonode.test.js
+++ b/tests/service/geonode.test.js
@@ -1,6 +1,6 @@
 import fetchMock from 'fetch-mock';
 
-import {uploadFiles, configure, importAll, allUploadedData, uploadedData} from '../../src/services/geonode';
+import {uploadFiles, configure, importAll, allUploadedData, uploadedData, getUsers, genericPost} from '../../src/services/geonode';
 
 describe('uploadFile', () => {
   beforeEach(function() {
@@ -109,6 +109,62 @@ describe('#uploadedData', () => {
     });
     it('returns result', () => {
       return assert.becomes(uploadedData(server, id), data);
+    });
+  });
+});
+describe('#genericPost', () => {
+  beforeEach(function() {
+		document.cookie = "csrftoken=1;";
+  });
+  let server = 'http://52.37.73.154';
+  let data = {
+    query: 'username'
+  };
+  let result = {
+    count: 1,
+    users: [
+      { username: "admin" }
+    ],
+    groups: []
+  }
+  describe('success', () => {
+    beforeEach(() => {
+      fetchMock
+      .post('http://52.37.73.154/account/ajax_lookup', result);
+    });
+    afterEach(() => {
+      fetchMock.restore();
+    });
+    it('returns user result', () => {
+      return assert.becomes(genericPost(server, 'account/ajax_lookup', data), result);
+    });
+  });
+});
+describe('#getUsers', () => {
+  beforeEach(function() {
+		document.cookie = "csrftoken=1;";
+  });
+  let server = 'http://52.37.73.154';
+  let data = {
+    query: 'username'
+  };
+  let result = {
+    count: 1,
+    users: [
+      { username: "admin" }
+    ],
+    groups: []
+  }
+  describe('success', () => {
+    beforeEach(() => {
+      fetchMock
+      .post('http://52.37.73.154/account/ajax_lookup', result);
+    });
+    afterEach(() => {
+      fetchMock.restore();
+    });
+    it('returns user result', () => {
+      return assert.becomes(getUsers(server, data), result);
     });
   });
 });


### PR DESCRIPTION
## What does this PR do?
It adds the ability to specify what will be shown when importing a layer. As well as map the import steps with the geonode/importer API.

I added defaults that are important or everybody uses and this is up for discussion how to structure the config. This is just the first draft and need broader discussion and more detailed specification. 

Right now a config looks as follow:

```
config: {
  edit_name: true,
  edit_time: false,
  other: []
}
```
The `other` can include anything and has the following structure:
```
{title: 'Layer Name', api_name: 'layerName', type: 'text'}
```
right now I have two types of fields that are available: `text`, `fields` and I imagine having at least a few more, for example `switch` (for yes/no) and `select`.
The `fields` type just shows a select box with all entries from the layer to select from.